### PR TITLE
New crawlers and updates to crawling section

### DIFF
--- a/dexter/app.py
+++ b/dexter/app.py
@@ -69,7 +69,7 @@ from .attachments import setup_attachments
 setup_attachments(app)
 
 # celery tasks
-if env == 'development':
+if env == 'production':
     from celery import Celery
     celery_app = Celery('dexter', include=['dexter.tasks', 'dexter.app'])
     celery_app.config_from_object('dexter.config.celeryconfig')

--- a/dexter/app.py
+++ b/dexter/app.py
@@ -69,7 +69,7 @@ from .attachments import setup_attachments
 setup_attachments(app)
 
 # celery tasks
-if env == 'production':
+if env == 'development':
     from celery import Celery
     celery_app = Celery('dexter', include=['dexter.tasks', 'dexter.app'])
     celery_app.config_from_object('dexter.config.celeryconfig')

--- a/dexter/models/country.py
+++ b/dexter/models/country.py
@@ -48,6 +48,7 @@ Namibia|na
 Zimbabwe|zw
 Tanzania|tz
 Germany|de
+United Kingdom (Great Britain)|gb
             """
 
         countries = []

--- a/dexter/models/country.py
+++ b/dexter/models/country.py
@@ -47,6 +47,7 @@ Zambia|zm
 Namibia|na
 Zimbabwe|zw
 Tanzania|tz
+Germany|de
             """
 
         countries = []

--- a/dexter/models/country.py
+++ b/dexter/models/country.py
@@ -45,6 +45,7 @@ South Africa|za
 Lesotho|ls
 Zambia|zm
 Namibia|na
+Zimbabwe|zw
             """
 
         countries = []

--- a/dexter/models/country.py
+++ b/dexter/models/country.py
@@ -49,6 +49,7 @@ Zimbabwe|zw
 Tanzania|tz
 Germany|de
 United Kingdom (Great Britain)|gb
+Kenya|ke
             """
 
         countries = []

--- a/dexter/models/country.py
+++ b/dexter/models/country.py
@@ -46,6 +46,7 @@ Lesotho|ls
 Zambia|zm
 Namibia|na
 Zimbabwe|zw
+Tanzania|tz
             """
 
         countries = []

--- a/dexter/models/fdi.py
+++ b/dexter/models/fdi.py
@@ -492,7 +492,7 @@ class InvestmentOrigins(db.Model):
     __tablename__ = "investment_origins"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String(50), index=True, nullable=False, unique=True)
+    name = Column(String(55), index=True, nullable=False, unique=True)
 
     def __repr__(self):
         return "<Investment origin='%s'>" % (self.name)

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -168,6 +168,7 @@ NewsDay Zimbabwe|online|newsday.co.zw||zw
 The Citizen Tanzania|online|thecitizen.co.tz||tz
 Deutsche Welle|online|dw.com||de
 BBC|online|bbc.com||gb
+Daily Nation (Kenya)|online|nation.co.ke||ke
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -137,6 +137,7 @@ Zambian Watchdog|online|zambianwatchdog.com||zm
 Zambia Daily Mail|online|daily-mail.co.zm||zm
 Post Zambia|online|postzambia.com||zm
 Times of Zambia|online|times.co.zm||zm
+The Chronicle|online|chronicle.co.zw||zw
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -39,7 +39,8 @@ class Medium(db.Model):
         calls fail to recognise urls (eg: .co.tz fials...)
         """
         url_exceptions = [
-            'thecitizen.co.tz'
+            'thecitizen.co.tz',
+            'dailynews.co.tz'
         ]
         for ex in url_exceptions: 
             # check if it exists in the url add buffer for [https://www.] characters at start

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -167,6 +167,7 @@ The Chronicle|online|chronicle.co.zw||zw
 NewsDay Zimbabwe|online|newsday.co.zw||zw
 The Citizen Tanzania|online|thecitizen.co.tz||tz
 Deutsche Welle|online|dw.com||de
+BBC|online|bbc.com||gb
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -138,6 +138,7 @@ Zambia Daily Mail|online|daily-mail.co.zm||zm
 Post Zambia|online|postzambia.com||zm
 Times of Zambia|online|times.co.zm||zm
 The Chronicle|online|chronicle.co.zw||zw
+NewsDay Zimbabwe|online|newsday.co.zw||zw
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -172,6 +172,8 @@ Daily Nation (Kenya)|online|nation.co.ke||ke
 Standard Digital|online|standardmedia.co.ke||ke
 The Star (Kenya)|online|the-star.co.ke||ke
 The East African|online|theeastafrican.co.ke||ke
+Daily News (Tanzania)|online|dailynews.co.tz||tz
+Daily News (Zimbabwe)|online|dailynews.co.zw||tz
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -170,6 +170,7 @@ Deutsche Welle|online|dw.com||de
 BBC|online|bbc.com||gb
 Daily Nation (Kenya)|online|nation.co.ke||ke
 Standard Digital|online|standardmedia.co.ke||ke
+The Star (Kenya)|online|the-star.co.ke||ke
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -139,6 +139,7 @@ Post Zambia|online|postzambia.com||zm
 Times of Zambia|online|times.co.zm||zm
 The Chronicle|online|chronicle.co.zw||zw
 NewsDay Zimbabwe|online|newsday.co.zw||zw
+The Citizen Tanzania|online|thecitizen.co.tz||tz
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -171,6 +171,7 @@ BBC|online|bbc.com||gb
 Daily Nation (Kenya)|online|nation.co.ke||ke
 Standard Digital|online|standardmedia.co.ke||ke
 The Star (Kenya)|online|the-star.co.ke||ke
+The East African|online|theeastafrican.co.ke||ke
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -169,6 +169,7 @@ The Citizen Tanzania|online|thecitizen.co.tz||tz
 Deutsche Welle|online|dw.com||de
 BBC|online|bbc.com||gb
 Daily Nation (Kenya)|online|nation.co.ke||ke
+Standard Digital|online|standardmedia.co.ke||ke
             """
 
         mediums = []

--- a/dexter/models/medium.py
+++ b/dexter/models/medium.py
@@ -166,6 +166,7 @@ Times of Zambia|online|times.co.zm||zm
 The Chronicle|online|chronicle.co.zw||zw
 NewsDay Zimbabwe|online|newsday.co.zw||zw
 The Citizen Tanzania|online|thecitizen.co.tz||tz
+Deutsche Welle|online|dw.com||de
             """
 
         mediums = []

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -9,3 +9,4 @@ from .generic import GenericCrawler
 from .newstools import NewstoolsCrawler
 from .zambia import ZambiaDailyNationCrawler, LusakaTimesCrawler, ZambianWatchdogCrawler, ZambiaDailyMailCrawler, PostZambiaCrawler, TimesZambiaCrawler
 from .nationke import NationKECrawler
+from .standardmedia import StandardMediaCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -11,3 +11,4 @@ from .zambia import ZambiaDailyNationCrawler, LusakaTimesCrawler, ZambianWatchdo
 from .nationke import NationKECrawler
 from .standardmedia import StandardMediaCrawler
 from .thestarke import TheStarKECrawler
+from .theeastafricanke import TheEastAfricanKECrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -12,4 +12,5 @@ from .nationke import NationKECrawler
 from .standardmedia import StandardMediaCrawler
 from .thestarke import TheStarKECrawler
 from .theeastafricanke import TheEastAfricanKECrawler
-from .dailynewstz import DilyNewsTZCrawler
+from .dailynewstz import DailyNewsTZCrawler
+from .dailynewszw import DailyNewsZWCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -10,3 +10,4 @@ from .newstools import NewstoolsCrawler
 from .zambia import ZambiaDailyNationCrawler, LusakaTimesCrawler, ZambianWatchdogCrawler, ZambiaDailyMailCrawler, PostZambiaCrawler, TimesZambiaCrawler
 from .nationke import NationKECrawler
 from .standardmedia import StandardMediaCrawler
+from .thestarke import TheStarKECrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -8,3 +8,4 @@ from .namibian import NamibianCrawler
 from .generic import GenericCrawler
 from .newstools import NewstoolsCrawler
 from .zambia import ZambiaDailyNationCrawler, LusakaTimesCrawler, ZambianWatchdogCrawler, ZambiaDailyMailCrawler, PostZambiaCrawler, TimesZambiaCrawler
+from .nationke import NationKECrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -12,3 +12,4 @@ from .nationke import NationKECrawler
 from .standardmedia import StandardMediaCrawler
 from .thestarke import TheStarKECrawler
 from .theeastafricanke import TheEastAfricanKECrawler
+from .dailynewstz import DilyNewsTZCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -14,3 +14,4 @@ from .thestarke import TheStarKECrawler
 from .theeastafricanke import TheEastAfricanKECrawler
 from .dailynewstz import DailyNewsTZCrawler
 from .dailynewszw import DailyNewsZWCrawler
+from .thecitizentz import TheCitizenTZCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -18,3 +18,4 @@ from .thecitizentz import TheCitizenTZCrawler
 from .newsdayzw import NewsDayZWCrawler
 from .dwcom import DWCrawler
 from .chroniclezw import ChronicleZWCrawler
+from .bbc import BBCCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -15,3 +15,4 @@ from .theeastafricanke import TheEastAfricanKECrawler
 from .dailynewstz import DailyNewsTZCrawler
 from .dailynewszw import DailyNewsZWCrawler
 from .thecitizentz import TheCitizenTZCrawler
+from .newsdayzw import NewsDayZWCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -16,3 +16,4 @@ from .dailynewstz import DailyNewsTZCrawler
 from .dailynewszw import DailyNewsZWCrawler
 from .thecitizentz import TheCitizenTZCrawler
 from .newsdayzw import NewsDayZWCrawler
+from .dwcom import DWCrawler

--- a/dexter/processing/crawlers/__init__.py
+++ b/dexter/processing/crawlers/__init__.py
@@ -17,3 +17,4 @@ from .dailynewszw import DailyNewsZWCrawler
 from .thecitizentz import TheCitizenTZCrawler
 from .newsdayzw import NewsDayZWCrawler
 from .dwcom import DWCrawler
+from .chroniclezw import ChronicleZWCrawler

--- a/dexter/processing/crawlers/base.py
+++ b/dexter/processing/crawlers/base.py
@@ -18,7 +18,6 @@ class BaseCrawler(object):
         """ Strip anchors, etc."""
 
         # Needed to handle urls being recieved without protocol (http[s]://), check if it can be parsed first, then handle and re parse if there is no netloc found
-        # Also checking for any www. to handle these in particular. otherwise it should still fail (perhaps need to handle other outliers in future)
         if '//' not in url:
             url = '%s%s' % ('http://', url)
 

--- a/dexter/processing/crawlers/bbc.py
+++ b/dexter/processing/crawlers/bbc.py
@@ -1,0 +1,45 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+import logging
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class BBCCrawler(BaseCrawler):
+    BBC = re.compile('(www\.)?bbc.com')
+    log = logging.getLogger(__name__)
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.BBC.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        # raw_html = raw_html.encode("utf-8")
+        # raw_html = unicode(raw_html, errors='ignore')
+
+        super(BBCCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select("#page .story-body .story-body__h1 "))
+
+        #gather text and summary
+        nodes = soup.select("#page .story-body .story-body__inner p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes[1:])
+        
+        #gather publish date
+        date = self.extract_plaintext(soup.select("#page .story-body .story-body__mini-info-list-and-share .date"))
+        doc.published_at = self.parse_timestamp(date)
+
+        # gather author 
+        # no authors on pages
+        doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/chroniclezw.py
+++ b/dexter/processing/crawlers/chroniclezw.py
@@ -1,0 +1,48 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+import logging
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class ChronicleZWCrawler(BaseCrawler):
+    CZW = re.compile('(www\.)?chronicle.co.zw')
+    log = logging.getLogger(__name__)
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.CZW.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        # raw_html = raw_html.encode("utf-8")
+        # raw_html = unicode(raw_html, errors='ignore')
+
+        super(ChronicleZWCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select("#primary #content .post .entry-header .entry-title"))
+
+        #gather text and summary
+        nodes = soup.select("#primary #content .post .entry-content p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes[1:])
+        
+        #gather publish date
+        date = self.extract_plaintext(soup.select("#primary #content .post .entry-header .entry-meta .date"))
+        doc.published_at = self.parse_timestamp(date)
+
+        # gather author 
+        author = self.extract_plaintext(soup.select("#primary #content .post .entry-header .entry-meta .author")).strip()
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/dailynewstz.py
+++ b/dexter/processing/crawlers/dailynewstz.py
@@ -15,6 +15,7 @@ class DailyNewsTZCrawler(BaseCrawler):
         parts = urlparse(url)
         return bool(self.DNTZ_RE.match(parts.netloc))
 
+
     def extract(self, doc, raw_html):
         """ Extract text and other things from the raw_html for this document. """
         super(DailyNewsTZCrawler, self).extract(doc, raw_html)

--- a/dexter/processing/crawlers/dailynewstz.py
+++ b/dexter/processing/crawlers/dailynewstz.py
@@ -1,0 +1,41 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class DilyNewsTZCrawler(BaseCrawler):
+    DNTZ_RE = re.compile('(www\.)?dailynews.co.tz')
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.DNTZ_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        super(DilyNewsTZCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select(".article-main .article-header .article-title"))
+
+        #gather publish date
+        doc.published_at = self.extract_plaintext(soup.select(".article-main .article-aside .published time"))
+        
+        #gather text and summary
+        doc.summary = soup.select(".article-main .article-full .article-content-main .article-intro p")
+        nodes = soup.select(".article-main .article-full .article-content-main .article-content p")
+        doc.text = "\n\n".join(p.text.strip() for p in nodes)
+
+        # gather author 
+        author = self.extract_plaintext(soup.select(".article-main .article-aside .createdby span:first-child"))
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/dailynewstz.py
+++ b/dexter/processing/crawlers/dailynewstz.py
@@ -25,10 +25,11 @@ class DilyNewsTZCrawler(BaseCrawler):
         doc.title = self.extract_plaintext(soup.select(".article-main .article-header .article-title"))
 
         #gather publish date
-        doc.published_at = self.extract_plaintext(soup.select(".article-main .article-aside .published time"))
+        date = self.extract_plaintext(soup.select(".article-main .article-aside .published time"))
+        doc.published_at = self.parse_timestamp(date)
         
         #gather text and summary
-        doc.summary = soup.select(".article-main .article-full .article-content-main .article-intro p")
+        doc.summary = self.extract_plaintext(soup.select(".article-main .article-full .article-content-main .article-intro p"))
         nodes = soup.select(".article-main .article-full .article-content-main .article-content p")
         doc.text = "\n\n".join(p.text.strip() for p in nodes)
 

--- a/dexter/processing/crawlers/dailynewstz.py
+++ b/dexter/processing/crawlers/dailynewstz.py
@@ -7,7 +7,7 @@ import requests
 from .base import BaseCrawler
 from ...models import Entity, Author, AuthorType
 
-class DilyNewsTZCrawler(BaseCrawler):
+class DailyNewsTZCrawler(BaseCrawler):
     DNTZ_RE = re.compile('(www\.)?dailynews.co.tz')
 
     def offer(self, url):
@@ -17,7 +17,7 @@ class DilyNewsTZCrawler(BaseCrawler):
 
     def extract(self, doc, raw_html):
         """ Extract text and other things from the raw_html for this document. """
-        super(DilyNewsTZCrawler, self).extract(doc, raw_html)
+        super(DailyNewsTZCrawler, self).extract(doc, raw_html)
 
         soup = BeautifulSoup(raw_html)
 

--- a/dexter/processing/crawlers/dailynewszw.py
+++ b/dexter/processing/crawlers/dailynewszw.py
@@ -37,7 +37,7 @@ class DailyNewsZWCrawler(BaseCrawler):
         doc.text = "\n\n".join(p.text.strip() for p in nodes[1:])
 
         # gather author 
-        author = date = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[0]
+        author = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[0]
         if author:
             doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
         else:

--- a/dexter/processing/crawlers/dailynewszw.py
+++ b/dexter/processing/crawlers/dailynewszw.py
@@ -1,0 +1,46 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+import logging
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class DailyNewsZWCrawler(BaseCrawler):
+    DNZW_RE = re.compile('(www\.)?dailynews.co.zw')
+    log = logging.getLogger(__name__)
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.DNZW_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        super(DailyNewsZWCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select(".wrapper .content > h1"))
+
+        #gather publish date
+        date = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[1]
+        self.log.info(date)
+        doc.published_at = self.parse_timestamp(date)
+        
+        #gather text and summary
+        nodes = soup.select(".wrapper .content .left #article p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[1:2])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes[1:])
+
+        # gather author 
+        author = date = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[0]
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/dwcom.py
+++ b/dexter/processing/crawlers/dwcom.py
@@ -1,0 +1,56 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+import logging
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class DWCrawler(BaseCrawler):
+    DW = re.compile('(www\.)?dw.com')
+    log = logging.getLogger(__name__)
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.DW.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        raw_html = raw_html.encode("utf-8")
+        raw_html = unicode(raw_html, errors='ignore')
+
+        super(DWCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select("#innerFrame #bodyContent .col3 > h1"))
+
+        #gather text and summary
+        doc.summary = self.extract_plaintext(soup.select("#innerFrame #bodyContent .col3 .intro"))
+
+        nodes = soup.select("#innerFrame #bodyContent .col3 .group .longText p")
+        doc.text = "\n\n".join(p.text.strip() for p in nodes)
+        
+        #gather publish date
+        list_data = soup.select("#innerFrame #bodyContent .col3 > .group > .smallList > li")
+        for node in list_data:
+            # find Date
+            if node.text.find("Date") > -1:
+                date = node.text.replace("Date", "")
+            # find Author
+            if node.text.find("Author") > -1:
+                author = node.text.replace("Author", "")
+
+        doc.published_at = self.parse_timestamp(date)
+
+        # gather author 
+        author = author.strip()
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/nationke.py
+++ b/dexter/processing/crawlers/nationke.py
@@ -1,0 +1,48 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class NationKECrawler(BaseCrawler):
+    NAKE_RE = re.compile('(www\.)?nation.co.ke')
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.NAKE_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        
+        # need to strip illegal 4 byte characters present on this site like the dot on form submission button: "\xee\x80\x81" ( \uE001 )
+        raw_html = raw_html.replace(u"\uE001", "")
+
+        super(NationKECrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+
+        doc.title = self.extract_plaintext(soup.select(".container .main .story-view header h1"))
+    
+        nodes = soup.select(".container .main .story-view .article .body-copy > div > p")
+        doc.text = "\n\n".join(p.getText().strip() for p in nodes)
+        self.log.info(doc.text)
+
+        published_text = self.extract_plaintext(soup.select(".container .main .story-view header h5"))
+        doc.published_at = self.parse_timestamp(published_text)
+
+        author_text = soup.select(".container .main .story-view .article .body-copy .author strong")
+        author = self.extract_plaintext(author_text).replace("By ", '')
+        
+        # detect a junk author
+        if len(author) > 100 or author.count(' ') > 5:
+            author = None
+
+        if author:
+            doc.author = Author.get_or_create(author, AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()

--- a/dexter/processing/crawlers/nationke.py
+++ b/dexter/processing/crawlers/nationke.py
@@ -30,7 +30,6 @@ class NationKECrawler(BaseCrawler):
     
         nodes = soup.select(".container .main .story-view .article .body-copy > div > p")
         doc.text = "\n\n".join(p.getText().strip() for p in nodes)
-        self.log.info(doc.text)
 
         published_text = self.extract_plaintext(soup.select(".container .main .story-view header h5"))
         doc.published_at = self.parse_timestamp(published_text)

--- a/dexter/processing/crawlers/newsdayzw.py
+++ b/dexter/processing/crawlers/newsdayzw.py
@@ -1,0 +1,49 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+import logging
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class NewsDayZWCrawler(BaseCrawler):
+    NDZW = re.compile('(www\.)?newsday.co.zw')
+    log = logging.getLogger(__name__)
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.NDZW.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        # cleaning up the raw_html as is seems unicode 4byte characters are present which will error with DB
+        raw_html = raw_html.encode("utf-8")
+        raw_html = unicode(raw_html, errors='ignore')
+
+        super(NewsDayZWCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select("#content #main article.post header h1"))
+
+        #gather publish date
+        date = self.extract_plaintext(soup.select("#content #main article.post .post-meta .date.published"))
+        doc.published_at = self.parse_timestamp(date)
+        
+        #gather text and summary
+        nodes = soup.select("#content #main article.post .entry p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[0:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes[2:])
+
+        # gather author 
+        author = self.extract_plaintext(nodes[1:2]).replace("BY ", "")
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/standardmedia.py
+++ b/dexter/processing/crawlers/standardmedia.py
@@ -1,0 +1,43 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class StandardMediaCrawler(BaseCrawler):
+    SM_RE = re.compile('(www\.)?standardmedia.co.ke')
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.SM_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        super(StandardMediaCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select(".site-wrapper .container .main-title-inner h2"))
+
+        #gather publish date
+        published_text = soup.find(attrs={"name":"pubdate"})['content']
+        doc.published_at = self.parse_timestamp(published_text)
+        
+        #gather text and summary
+        nodes = soup.select(".main-article p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[0:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes)
+
+        # gather author
+        author = self.extract_plaintext(soup.select(".site-wrapper .container .date")).replace("By ", '')
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/thecitizentz.py
+++ b/dexter/processing/crawlers/thecitizentz.py
@@ -17,6 +17,7 @@ class TheCitizenTZCrawler(BaseCrawler):
         parts = urlparse(url)
         return bool(self.TCTZ.match(parts.netloc))
 
+
     def extract(self, doc, raw_html):
         """ Extract text and other things from the raw_html for this document. """
         super(TheCitizenTZCrawler, self).extract(doc, raw_html)

--- a/dexter/processing/crawlers/thecitizentz.py
+++ b/dexter/processing/crawlers/thecitizentz.py
@@ -8,36 +8,36 @@ import logging
 from .base import BaseCrawler
 from ...models import Entity, Author, AuthorType
 
-class DailyNewsZWCrawler(BaseCrawler):
-    DNZW_RE = re.compile('(www\.)?dailynews.co.zw')
+class TheCitizenTZCrawler(BaseCrawler):
+    TCTZ = re.compile('(www\.)?thecitizen.co.tz')
     log = logging.getLogger(__name__)
 
     def offer(self, url):
         """ Can this crawler process this URL? """
         parts = urlparse(url)
-        return bool(self.DNZW_RE.match(parts.netloc))
+        return bool(self.TCTZ.match(parts.netloc))
 
     def extract(self, doc, raw_html):
         """ Extract text and other things from the raw_html for this document. """
-        super(DailyNewsZWCrawler, self).extract(doc, raw_html)
+        super(TheCitizenTZCrawler, self).extract(doc, raw_html)
 
         soup = BeautifulSoup(raw_html)
 
         # gather title
-        doc.title = self.extract_plaintext(soup.select(".wrapper .content > h1"))
+        doc.title = self.extract_plaintext(soup.select("article.main.column .story-view header h1"))
 
         #gather publish date
-        date = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[1]
+        date = self.extract_plaintext(soup.select("article.main.column .story-view header h5"))
         doc.published_at = self.parse_timestamp(date)
         
         #gather text and summary
-        nodes = soup.select(".wrapper .content .left #article p")
+        nodes = soup.select("article.main.column .story-view .article .body-copy p")
         if len(nodes) > 1:
             doc.summary = self.extract_plaintext(nodes[1:2])
         doc.text = "\n\n".join(p.text.strip() for p in nodes[1:])
 
         # gather author 
-        author = date = self.extract_plaintext(soup.select(".wrapper .content .left #article .byline")).replace(u'\xa0', ' ').split(u'\u2022')[0]
+        author = date = self.extract_plaintext(soup.select("article.main.column .story-view .article .author")).replace("By ", '').split('@')[0]
         if author:
             doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
         else:

--- a/dexter/processing/crawlers/theeastafricanke.py
+++ b/dexter/processing/crawlers/theeastafricanke.py
@@ -1,0 +1,43 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class TheEastAfricanKECrawler(BaseCrawler):
+    TEAKE_RE = re.compile('(www\.)?theeastafrican.co.ke')
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.TEAKE_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        super(TheEastAfricanKECrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select("#articlebody h1"))
+
+        #gather publish date
+        published_text = soup.find(attrs={"name":"pubdate"})['content']
+        doc.published_at = self.parse_timestamp(published_text)
+        
+        #gather text and summary
+        nodes = soup.select("#contentwrapper #article_text p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[0:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes)
+
+        # gather author 
+        author = self.extract_plaintext(soup.find(attrs={"property":"og:author"})['content']).strip()
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/theeastafricanke.py
+++ b/dexter/processing/crawlers/theeastafricanke.py
@@ -25,7 +25,8 @@ class TheEastAfricanKECrawler(BaseCrawler):
         doc.title = self.extract_plaintext(soup.select("#articlebody h1"))
 
         #gather publish date
-        published_text = soup.find(attrs={"name":"pubdate"})['content']
+        self.log.info(self.extract_plaintext(soup.select("#articlemeta")))
+        published_text = self.extract_plaintext(soup.select("#articlemeta")).split("Posted",1)[1].strip("\n").replace(u'\xa0', ' ')
         doc.published_at = self.parse_timestamp(published_text)
         
         #gather text and summary
@@ -35,7 +36,7 @@ class TheEastAfricanKECrawler(BaseCrawler):
         doc.text = "\n\n".join(p.text.strip() for p in nodes)
 
         # gather author 
-        author = self.extract_plaintext(soup.find(attrs={"property":"og:author"})['content']).strip()
+        author = soup.find(attrs={"property":"og:author"})['content'].rstrip(", ")
         if author:
             doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
         else:

--- a/dexter/processing/crawlers/theeastafricanke.py
+++ b/dexter/processing/crawlers/theeastafricanke.py
@@ -25,7 +25,6 @@ class TheEastAfricanKECrawler(BaseCrawler):
         doc.title = self.extract_plaintext(soup.select("#articlebody h1"))
 
         #gather publish date
-        self.log.info(self.extract_plaintext(soup.select("#articlemeta")))
         published_text = self.extract_plaintext(soup.select("#articlemeta")).split("Posted",1)[1].strip("\n").replace(u'\xa0', ' ')
         doc.published_at = self.parse_timestamp(published_text)
         

--- a/dexter/processing/crawlers/thestarke.py
+++ b/dexter/processing/crawlers/thestarke.py
@@ -1,0 +1,43 @@
+from urlparse import urlparse, urlunparse
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from .base import BaseCrawler
+from ...models import Entity, Author, AuthorType
+
+class TheStarKECrawler(BaseCrawler):
+    TSKE_RE = re.compile('(www\.)?standardmedia.co.ke')
+
+    def offer(self, url):
+        """ Can this crawler process this URL? """
+        parts = urlparse(url)
+        return bool(self.TSKE_RE.match(parts.netloc))
+
+    def extract(self, doc, raw_html):
+        """ Extract text and other things from the raw_html for this document. """
+        super(StandardMediaCrawler, self).extract(doc, raw_html)
+
+        soup = BeautifulSoup(raw_html)
+
+        # gather title
+        doc.title = self.extract_plaintext(soup.select(".l-region--title .pane-page-title h1"))
+
+        #gather publish date
+        published_text = soup.find(attrs={"property":"og:updated_time"})['content']
+        doc.published_at = self.parse_timestamp(published_text)
+        
+        #gather text and summary
+        nodes = soup.select(".l-region--content .panel-pane .pane-node-content .field p")
+        if len(nodes) > 1:
+            doc.summary = self.extract_plaintext(nodes[0:1])
+        doc.text = "\n\n".join(p.text.strip() for p in nodes)
+
+        # gather author
+        author = self.extract_plaintext(soup.select(".pane-node-field-converge-byline .field--name-field-converge-byline .field__item")).replace("By ", '').split('@')[0]
+        if author:
+            doc.author = Author.get_or_create(author.strip(), AuthorType.journalist())
+        else:
+            doc.author = Author.unknown()
+

--- a/dexter/processing/crawlers/thestarke.py
+++ b/dexter/processing/crawlers/thestarke.py
@@ -7,8 +7,10 @@ import requests
 from .base import BaseCrawler
 from ...models import Entity, Author, AuthorType
 
+import time
+
 class TheStarKECrawler(BaseCrawler):
-    TSKE_RE = re.compile('(www\.)?standardmedia.co.ke')
+    TSKE_RE = re.compile('(www\.)?the-star.co.ke')
 
     def offer(self, url):
         """ Can this crawler process this URL? """
@@ -17,7 +19,7 @@ class TheStarKECrawler(BaseCrawler):
 
     def extract(self, doc, raw_html):
         """ Extract text and other things from the raw_html for this document. """
-        super(StandardMediaCrawler, self).extract(doc, raw_html)
+        super(TheStarKECrawler, self).extract(doc, raw_html)
 
         soup = BeautifulSoup(raw_html)
 
@@ -25,7 +27,7 @@ class TheStarKECrawler(BaseCrawler):
         doc.title = self.extract_plaintext(soup.select(".l-region--title .pane-page-title h1"))
 
         #gather publish date
-        published_text = soup.find(attrs={"property":"og:updated_time"})['content']
+        published_text = soup.find(attrs={"property":"og:updated_time"})['content'][:-6] # remove timezone, throwing exceptions since parse() not handling it well enough
         doc.published_at = self.parse_timestamp(published_text)
         
         #gather text and summary

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -37,10 +37,11 @@ class DocumentProcessor:
             ZambiaDailyMailCrawler(),
             PostZambiaCrawler(),
             TimesZambiaCrawler(),
+            NationKECrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [
-            AlchemyExtractor(),
+            # AlchemyExtractor(),
             CalaisExtractor(),
             SourcesExtractor(),
             PlacesExtractor()]

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -51,7 +51,7 @@ class DocumentProcessor:
             # must come last
             GenericCrawler()]
         self.extractors = [
-            # AlchemyExtractor(),
+            AlchemyExtractor(),
             CalaisExtractor(),
             SourcesExtractor(),
             PlacesExtractor()]

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -40,6 +40,7 @@ class DocumentProcessor:
             NationKECrawler(),
             StandardMediaCrawler(),
             TheStarKECrawler(),
+            TheEastAfricanKECrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -47,6 +47,7 @@ class DocumentProcessor:
             NewsDayZWCrawler(),
             DWCrawler(),
             ChronicleZWCrawler(),
+            BBCCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -38,6 +38,7 @@ class DocumentProcessor:
             PostZambiaCrawler(),
             TimesZambiaCrawler(),
             NationKECrawler(),
+            StandardMediaCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -44,6 +44,7 @@ class DocumentProcessor:
             DailyNewsTZCrawler(),
             DailyNewsZWCrawler(),
             TheCitizenTZCrawler(),
+            NewsDayZWCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -41,7 +41,8 @@ class DocumentProcessor:
             StandardMediaCrawler(),
             TheStarKECrawler(),
             TheEastAfricanKECrawler(),
-            DilyNewsTZCrawler(),
+            DailyNewsTZCrawler(),
+            DailyNewsZWCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -45,7 +45,7 @@ class DocumentProcessor:
             # must come last
             GenericCrawler()]
         self.extractors = [
-            AlchemyExtractor(),
+            # AlchemyExtractor(),
             CalaisExtractor(),
             SourcesExtractor(),
             PlacesExtractor()]

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -43,6 +43,7 @@ class DocumentProcessor:
             TheEastAfricanKECrawler(),
             DailyNewsTZCrawler(),
             DailyNewsZWCrawler(),
+            TheCitizenTZCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -46,6 +46,7 @@ class DocumentProcessor:
             TheCitizenTZCrawler(),
             NewsDayZWCrawler(),
             DWCrawler(),
+            ChronicleZWCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -41,6 +41,7 @@ class DocumentProcessor:
             StandardMediaCrawler(),
             TheStarKECrawler(),
             TheEastAfricanKECrawler(),
+            DilyNewsTZCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -40,7 +40,7 @@ class DocumentProcessor:
             # must come last
             GenericCrawler()]
         self.extractors = [
-            AlchemyExtractor(),
+            # AlchemyExtractor(),
             CalaisExtractor(),
             SourcesExtractor(),
             PlacesExtractor()]

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -44,7 +44,7 @@ class DocumentProcessor:
             # must come last
             GenericCrawler()]
         self.extractors = [
-            # AlchemyExtractor(),
+            AlchemyExtractor(),
             CalaisExtractor(),
             SourcesExtractor(),
             PlacesExtractor()]

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -45,6 +45,7 @@ class DocumentProcessor:
             DailyNewsZWCrawler(),
             TheCitizenTZCrawler(),
             NewsDayZWCrawler(),
+            DWCrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [

--- a/dexter/processing/document_processor.py
+++ b/dexter/processing/document_processor.py
@@ -39,6 +39,7 @@ class DocumentProcessor:
             TimesZambiaCrawler(),
             NationKECrawler(),
             StandardMediaCrawler(),
+            TheStarKECrawler(),
             # must come last
             GenericCrawler()]
         self.extractors = [


### PR DESCRIPTION
- Added new Medium entries to seeders for the following with respective crawlers:
    chronicle.co.zw The Chronicle 
    newsday.co.zw   NewsDay Zimbabwe 
    thecitizen.co.tz    The Citizen Tanzania 
    dw.com  Deutsche Welle 
    bbc.com BBC 
    nation.co.ke    Daily Nation (Kenya)
    standardmedia.co.ke Standard Digital 
    the-star.co.ke  The Star (Kenya)
    theeastafrican.co.ke    The East African 
    dailynews.co.tz Daily News (Tanzania)
    dailynews.co.zw Daily News (Zimbabwe)

- Added Countries
    Zimbabwe    zw
    Tanzania    tz
    Germany  de
    United Kingdom (Great Britain)  gb
    Kenya   ke

- Updated `canonicalise_url` method in base crawler to better handle urls without stated protocol

- Added `is_tld_exception` method to medium model to handle urls that dont work with `get_tld` calls

- Added Parse catch debug info for Urls in document processor

- Updated FDI model field `name` to String(55) from String(50) to handle seeder record "Democratic People's Republic of Korea (North Korea)" String(51)
